### PR TITLE
Minor typo fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
 
 					<pre><code class="language-markup">&lt;script src="jellyfish.js"&gt;&lt;/script&gt;</code></pre>
 
-					<p>Don't forget to add the <code>img/loading.gif</code> image to your site, too. If you change its location, update the <code>loadingSrc</code> variable in <code>jellyfish.js</code></p>
+					<p>Don't forget to add the <code>img/loading.gif</code> image to your site, too. If you change its location, update the <code>loadingIcon</code> variable in <code>jellyfish.js</code></p>
 
 					<p class="text-muted"><span class="text-small"><span class="label">Heads Up!</span> Make sure to put your JS file in the footer or Jellyfish won't work (it's better for performance, too).</span></p>
 
@@ -200,7 +200,7 @@
 			<div class="row">
 				<div class="grid-two-thirds float-center">
 
-					<h1>Browser Compatability</h1>
+					<h1>Browser Compatibility</h1>
 
 					<p>Jellyfish works with all modern browsers, and IE 9 and above.</p>
 


### PR DESCRIPTION
I just noticed a couple of typos in the gh-pages/index.html file:
- The `loadingIcon` option is referred to as `loadingSrc` in the **Getting Started** guide
- Typo in "Compatibility"
