### PR TITLE
#26 - Remove console.log() call

### DIFF
--- a/src/js/jellyfish.js
+++ b/src/js/jellyfish.js
@@ -187,7 +187,6 @@
 	 * @param  {Object} settings
 	 */
 	var eventThrottler = function () {
-		console.log(eventTimeout);
 		if ( !eventTimeout ) {
 			eventTimeout = setTimeout( function() {
 				eventTimeout = null;


### PR DESCRIPTION
This PR should resolve #26 by removing the unnecessary console.log() call.
